### PR TITLE
Add utility 'file' to installs in dev/base

### DIFF
--- a/dev/base/Dockerfile
+++ b/dev/base/Dockerfile
@@ -39,6 +39,7 @@ RUN add-apt-repository ppa:ubuntu-elisp/ppa \
     && apt-get update \
     && apt-get install -yq --no-install-recommends \
     curl \
+    file \
     emacs-snapshot \
     emacs-snapshot-el \
     && apt-get clean \


### PR DESCRIPTION
Add utility 'file' to installs in dev/base Dockerfile.  This is now used in the WRF and WPS configure scripts.

Note: I haven't tested that this works (not sure how easily offhand), but this should be the correct package name