### PR TITLE
Specify the testcase to download

### DIFF
--- a/calibration_demo/Dockerfile
+++ b/calibration_demo/Dockerfile
@@ -59,7 +59,7 @@ RUN version=v5.0.2 \
     && release=$(curl -s https://api.github.com/repos/NCAR/wrf_hydro_nwm_public/releases/tags/$version) \
     && git clone --branch $version https://github.com/NCAR/wrf_hydro_nwm_public \
     && mv /home/docker/wrf_hydro_nwm_public /home/docker/wrf-hydro-training/wrf_hydro_nwm_public \
-    && exampleCaseURL=$(echo "$release" | grep 'testcase' | grep "browser_download_url" | cut -d : -f 2,3 |  tr -d \") \
+    && exampleCaseURL=$(echo "$release" | grep 'croton_NY_example_testcase' | grep "browser_download_url" | cut -d : -f 2,3 |  tr -d \") \
     && echo "$exampleCaseURL" | wget -qi -
 
 RUN tar -xf *testcase*.tar.gz \

--- a/training/entrypoint.sh
+++ b/training/entrypoint.sh
@@ -23,7 +23,7 @@ echo
 echo -e "\e[0;49;32m-----------------------------------\e[0m"
 echo -e "\e[7;49;32mRetrieving testcase\e[0m"
 
-exampleCaseURL=$(echo "$release" | grep 'testcase' \
+exampleCaseURL=$(echo "$release" | grep 'croton_NY_example_testcase' \
 | grep "browser_download_url" \
 | cut -d : -f 2,3 |  tr -d \")
 


### PR DESCRIPTION
Edits to the calibration demo Dockerfile and the training container entrypoint to grep for a more complete testcase name in order to avoid grabbing the coupled case inadvertently.