### PR TITLE
Update training version to v5.1.x

### DIFF
--- a/training/build.sh
+++ b/training/build.sh
@@ -1,5 +1,5 @@
 
  
-docker build "$@" -t wrfhydro/training:v5.0.x . 
+docker build "$@" -t wrfhydro/training:v5.1.x .
 
 exit $?

--- a/training/entrypoint.sh
+++ b/training/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-###Change the version here
-version=v5.0.3
+###Change the versions here
+version=v5.1.0
+training_branch=master
 ###########################
 
 
@@ -38,7 +39,7 @@ echo
 echo -e "\e[0;49;32m-----------------------------------\e[0m"
 echo -e "\e[7;49;32mRetrieving WRF-Hydro training\e[0m"
 
-git clone --branch ${version: 0:4}.x https://github.com/NCAR/wrf_hydro_training
+git clone --branch ${training_branch} https://github.com/NCAR/wrf_hydro_training
 mv /home/docker/wrf_hydro_training/lessons/training /home/docker/wrf-hydro-training/lessons
 rm -rf /home/docker/wrf_hydro_training/
 


### PR DESCRIPTION
Update the Dockerfile and build.sh to use v5.1.x of the code.
Add a separate training-package tag/branch variable to the training Dockerfile for cleaner separation