### PR TITLE
Added matplotlib and importlib-metadata to list of packages installed by pip

### DIFF
--- a/dev/modeltesting/Dockerfile
+++ b/dev/modeltesting/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER jamesmcc@ucar.edu
 ###################################
 
 #Install modules
-RUN pip install numpy netCDF4 pytest pytest-datadir-ng wrfhydropy==0.0.17
+RUN pip install numpy netCDF4 pytest pytest-datadir-ng wrfhydropy==0.0.17 matplotlib importlib-metadata==4.13.0
 
 ####################################
 ######### entrypoint ###########


### PR DESCRIPTION
Packages added to support difference plotting capability being added to testing workflow. Need to rebuild image  and push to dockerhub (wrfhydro/dev:modeltesting)