### PR TITLE
wrfhydropy Version Bump

### DIFF
--- a/dev/modeltesting/Dockerfile
+++ b/dev/modeltesting/Dockerfile
@@ -1,7 +1,7 @@
 ###################################
 # WRF-Hydro testing container
 # Purpose:
-#   Given a candidate and optionally a reference code repository, execute 
+#   Given a candidate and optionally a reference code repository, execute
 #   wrf_hydro_nwm_public tests
 # The above is achieved through entrypoint and host-side scripting.
 #
@@ -18,7 +18,7 @@ MAINTAINER jamesmcc@ucar.edu
 ###################################
 
 #Install modules
-RUN pip install numpy netCDF4 pytest pytest-datadir-ng wrfhydropy==0.0.17 matplotlib importlib-metadata==4.13.0
+RUN pip install numpy netCDF4 pytest pytest-datadir-ng wrfhydropy==0.0.18 matplotlib importlib-metadata==4.13.0
 
 ####################################
 ######### entrypoint ###########


### PR DESCRIPTION
A version bump of `wrfhydropy` was needed before I could successfully run `docker build ./` of the modeltesting container. 

Not sure if this will help the WRF-Hydor [github action CI issue](https://github.com/NCAR/wrf_hydro_nwm_public/actions) but it might get us further.

NOTE: tried to bump to latest `wrfhydropy 0.0.20` but it failed on finding matching dependencies. This issue will need to be examined at a later time 