### PR TITLE
bugfix: dev/base and dev/modeltesting

### DIFF
--- a/dev/base/Dockerfile
+++ b/dev/base/Dockerfile
@@ -4,8 +4,7 @@
 # Date:  2018-02-08
 ###################################
 
-FROM ubuntu:xenial
-MAINTAINER jamesmcc@ucar.edu
+FROM ubuntu:22.04
 
 ####################################
 ########## ROOT USER  ##############
@@ -22,16 +21,6 @@ RUN apt-get update \
 	&& apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-#Install additional tools
-RUN add-apt-repository ppa:ubuntu-elisp/ppa \
-    && apt-get update \
-    && apt-get install -yq --no-install-recommends \
-    curl \
-    file \
-    emacs-snapshot \
-    emacs-snapshot-el \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 ####################################
 ## WRF-Hydro dependencies
@@ -39,69 +28,73 @@ RUN add-apt-repository ppa:ubuntu-elisp/ppa \
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends \
     wget \
+    curl \
+    emacs-nox \
     bzip2 \
     ca-certificates \
-    vim \ 
+    vim \
     libhdf5-dev \
     gfortran \
     g++ \
     valgrind \
     m4 \
-    make \ 
+    make \
     libswitch-perl \
     git \
     nano \
     tcsh \
     bc \
+    mpich \
     less \
+    libxml2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --config csh
 
 ## Download, build, and install MPICH
-RUN MPICH_VERSION="3.2" \
+RUN MPICH_VERSION="4.1.2" \
     && MPICH_CONFIGURE_OPTIONS="" \
-    && MPICH_MAKE_OPTIONS='-j 2' \
+    && FCFLAGS="-fallow-argument-mismatch" \
     && mkdir /tmp/mpich-src \
     && cd /tmp/mpich-src \
     && wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \
-    && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
+    && tar xfz mpich-${MPICH_VERSION}.tar.gz \
     && cd mpich-${MPICH_VERSION}  \
-    && ./configure ${MPICH_CONFIGURE_OPTIONS}  \
-    && make ${MPICH_MAKE_OPTIONS} && make install \
+    && FCFLAGS=${FCFLAGS} ./configure ${MPICH_CONFIGURE_OPTIONS}  \
+    && make -j 2 && make install \
     && rm -rf /tmp/mpich-src
 
 #### TEST MPICH INSTALLATION ####
 ## Where is this from? Should we run the test?
-#WORKDIR /tmp/mpich-test
-#COPY mpich-test .
-#RUN mkdir /tmp/mpich-test \
-#    && test.sh \
-#    && RUN rm -rf /tmp/mpich-test
+# #WORKDIR /tmp/mpich-test
+# #COPY mpich-test .
+# #RUN mkdir /tmp/mpich-test \
+# #    && test.sh \
+# #    && RUN rm -rf /tmp/mpich-test
 
 ## install netcdf-C
 ENV H5DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial
 ENV HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 
-RUN NETCDF_C_VERSION="4.4.1.1" \
-    && wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-${NETCDF_C_VERSION}.tar.gz -P /tmp \
-    && tar -xf /tmp/netcdf-${NETCDF_C_VERSION}.tar.gz -C /tmp \
-    && cd /tmp/netcdf-${NETCDF_C_VERSION} \
+RUN NETCDF_C_VERSION="4.9.2" \
+    && wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v${NETCDF_C_VERSION}.tar.gz -P /tmp \
+    && tar -xf /tmp/v${NETCDF_C_VERSION}.tar.gz -C /tmp \
+    && cd /tmp/netcdf-c-${NETCDF_C_VERSION} \
     && CPPFLAGS=-I${H5DIR}/include LDFLAGS=-L${H5DIR}/lib ./configure --prefix=/usr/local \
-    && cd /tmp/netcdf-${NETCDF_C_VERSION} \
-    && make -j 2\
-    && cd /tmp/netcdf-${NETCDF_C_VERSION} \
+    && cd /tmp/netcdf-c-${NETCDF_C_VERSION} \
+    && make -j 2 \
+    && cd /tmp/netcdf-c-${NETCDF_C_VERSION} \
     && make install \
-    && rm -rf /tmp/netcdf-${NETCDF_C_VERSION}
+    && rm -rf /tmp/netcdf-c-${NETCDF_C_VERSION}
 
 # install netcdf-Fortran
 ENV NFDIR=/usr/local
 ENV LD_LIBRARY_PATH=${NCDIR}/lib
-RUN NETCDF_F_VERSION="4.4.4" \
+RUN NETCDF_F_VERSION="4.6.1" \
     && cd /tmp \
-    && wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-${NETCDF_F_VERSION}.tar.gz \
-    && tar -xf netcdf-fortran-${NETCDF_F_VERSION}.tar.gz \
+    && wget https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v${NETCDF_F_VERSION}.tar.gz \
+    && tar -xf v${NETCDF_F_VERSION}.tar.gz \
     && cd /tmp/netcdf-fortran-${NETCDF_F_VERSION} \
     && CPPFLAGS=-I${NCDIR}/include LDFLAGS=-L${NCDIR}/lib ./configure --prefix=${NFDIR} \
     && make -j 2\
@@ -114,7 +107,7 @@ ENV NCDIR=/usr/local
 ENV NETCDF_LIB=/usr/local/lib
 ENV NETCDF_INC=/usr/local/include
 
-## just to be sure 
+## just to be sure
 RUN rm -rf /tmp/*
 
 ###################################
@@ -128,26 +121,15 @@ RUN chmod -R 777 /home/docker/
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && bash Miniconda3-latest-Linux-x86_64.sh -b -p /home/docker/miniconda3 \
     && rm Miniconda3-latest-Linux-x86_64.sh \
-    && chown -R docker:docker /home/docker/miniconda3 
+    && chown -R docker:docker /home/docker/miniconda3
 
 #Set environment variables
 ENV PATH="/home/docker/miniconda3/bin:${PATH}"
 RUN conda update conda
-
-###################################
-## build nco and nccmp here. really not what I was hpoing for.
-#Get NCCMP to compare netcdf files
-RUN add-apt-repository ppa:remik-ziemlinski/nccmp && \
-        apt-get update && \
-        apt-get install -yq --no-install-recommends \
-	nco \
-	nccmp \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& rm -rf /tmp/*
+RUN conda install numpy>=1.23.5 conda-forge::nccmp
 
 ####################################
 ######### docker user ###########
 ####################################
 USER docker
 WORKDIR /home/docker
-

--- a/dev/modeltesting/Dockerfile
+++ b/dev/modeltesting/Dockerfile
@@ -11,14 +11,14 @@
 ###################################
 
 FROM wrfhydro/dev:base
-MAINTAINER jamesmcc@ucar.edu
 
 ###################################
 ### Python installations ##########
 ###################################
 
 #Install modules
-RUN pip install numpy netCDF4 pytest pytest-datadir-ng wrfhydropy==0.0.18 matplotlib importlib-metadata==4.13.0
+# RUN pip install --upgrade pip
+RUN pip install wrfhydropy>=0.0.21 gdown matplotlib importlib-metadata pytest pytest-datadir-ng numpy netCDF4
 
 ####################################
 ######### entrypoint ###########


### PR DESCRIPTION
Changes:
- bugfix: WRF-Hydro CI stopped working and needs `gdown` python package. dev/base and dev/modeltesting needed to be updated for this to work. Installing NetCDF and MPICH with`apt-get` works but then wrfhydropy wouldn't compile. Currently WRF-Hydro CI builds with wrfhydropy but fails during runtime.
- MAINTAINER tag is deprecated 

NOTE: current Docker Hub versions of dev/base and dev/modeltesting are built on this PR. Not best practice but there was some rush to get things working for WRF PR. 