### PR TITLE
bugfix: bumping R ncdf4 version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-TYPE: choose one of [fix, enhancement, feature, text only]
+TYPE: choose one of [bugfix, fix, enhancement, feature, text only]
 
 KEYWORDS: approximately 3 to 6 words related to your commit
 

--- a/dev/latest/Dockerfile
+++ b/dev/latest/Dockerfile
@@ -59,10 +59,12 @@ RUN conda install -y -c conda-forge \
     xrviz
 
 # R packages
-RUN wget https://cran.r-project.org/src/contrib/ncdf4_1.23.tar.gz \
-        && R CMD INSTALL ncdf4_1.23.tar.gz  \
-        && rm ncdf4_1.23.tar.gz \
-        && Rscript -e 'install.packages(c("optparse","stringr","plyr"), repos="https://cran.rstudio.com")'
+
+RUN ver=1.24 \
+    && wget https://cran.r-project.org/src/contrib/ncdf4_${ver}.tar.gz \
+    && R CMD INSTALL ncdf4_${ver}.tar.gz  \
+    && rm ncdf4_${ver}.tar.gz \
+    && Rscript -e 'install.packages(c("optparse","stringr","plyr"), repos="https://cran.rstudio.com")'
 
 # # Jupyter configuration script
 # COPY ./jupyter_notebook_config.py /home/docker/.jupyter/


### PR DESCRIPTION
TYPE: bugfix

KEYWORDS: CI, R Package, Docker

SOURCE: Soren Rasmusen, NSF NCAR

DESCRIPTION OF CHANGES: Bumping R ncdf4 version and adding version variable

TESTS CONDUCTED: built docker locally

NOTE: This failed locally and on my `main` branch when I updated it today. I'm holding off on merging this to see if the cron job fails tomorrow morning.

<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
