### PR TITLE
Hotfix: Python version selection

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build Docker image
+      - name: Build base Docker image
+        run: |
+          docker build -t wrfhydro/dev:base -f dev/base/Dockerfile .
+
+      - name: Build latest Docker image
         run: |
           docker build -t wrfhydro/dev:latest -f dev/latest/Dockerfile .

--- a/dev/latest/Dockerfile
+++ b/dev/latest/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     nco \
     nodejs \
     pkg-config \
+    python3.12 \
     python3-dask \
     python3-geopandas \
     python3-ipython \
@@ -49,6 +50,7 @@ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
 ENV PATH="/home/docker/miniconda3/bin:${PATH}"
 RUN conda install mamba -n base -c conda-forge
 RUN mamba install -y -c conda-forge \
+    python=3.12 \
     bash_kernel \
     conda-project \
     dask \


### PR DESCRIPTION
TYPE: hotfix

KEYWORDS: mamba, python

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Choosing Python version 3.12, otherwise mamba package manager can't get all the packages for 3.13, which was it's default version. This was causing the Docker CI build to fail.