### PR TITLE
Feature: automate pushing docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Build base Docker image
         run: |
-          docker build -t wrfhydro/dev:base -f dev/base/Dockerfile .
+          docker build -t wrfhydro/dev:base dev/base
 
       - name: Build latest Docker image
         run: |
-          docker build -t wrfhydro/dev:latest -f dev/latest/Dockerfile .
+          docker build -t wrfhydro/dev:latest dev/latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,41 @@
+name: push_docker
+
+on:
+  push:
+    branches:
+      # Only build containers when pushing to main
+      - "main"
+
+env:
+  BASE_TAG: wrfhydro/dev:base
+  LATEST_TAG: wrfhydro/dev:latest
+
+jobs:
+  docker:
+    if: github.repository == 'NCAR/wrf_hydro_docker'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check if secrets are defined
+        run: |
+          if [ -z "${{ secrets.DOCKERHUB_USERNAME }}" ]; then echo "Username is MISSING"; else echo "Username is SET"; fi
+          if [ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]; then echo "Token is MISSING"; else echo "Token is SET"; fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t ${{ env.BASE_TAG}} dev/base
+          docker build -t ${{ env.LATEST_TAG}} dev/latest
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.BASE_TAG }}
+          docker push ${{ env.LATEST_TAG }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #  WRF-Hydro® Docker Images <img src="https://ral.ucar.edu/sites/default/files/public/wrf_hydro_symbol_logo_2017_09_150pxby63px.png" width=100 align="left" />
 
 ![Build](https://github.com/NCAR/wrf_hydro_docker/actions/workflows/docker-build.yml/badge.svg)
+![Push](https://github.com/NCAR/wrf_hydro_docker/actions/workflows/docker-push.yml/badge.svg)
 
 # Description
 


### PR DESCRIPTION
TYPE: feature

KEYWORDS: Docker, Github  Actions

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: 
 - Build and push to dockerhub when main changes
 - Add push badge to README

TESTS CONDUCTED: Explicitly state if regression, integration, or unit tests were run before submitting.

NOTES: 
 - Did this because it seems my Dockerhub internet access was blocked by the place I'm staying at (it didn't appriatciate me pushing GBs of data to Dockerhub...) . This PR will automate this step so the Dockerhub images are always up-to-date with this repo's.


<!--
ITEMS THAT MIGHT BE USEFUL TO CONSIDER
 - Closes issue #xxxx
 - Tests added (unit tests and/or regression/integration tests)
 - Backwards compatible
 - Documentation included
 - Short description in the Development section of `NEWS.md`
--->
